### PR TITLE
natbib package update

### DIFF
--- a/LatexTemplate/prem/packages.tex
+++ b/LatexTemplate/prem/packages.tex
@@ -156,8 +156,12 @@
 \cftsetindents{section}{0em}{3em}
 %For reference
 
-\usepackage{natbib}
+%\usepackage{natbib}
 %\bibliographystyle{apalike}%\usepackage{apalike}
+%% Modification
+\usepackage[colon]{natbib}
+
+
 
 \setlength{\bibhang}{0pt}
 


### PR DESCRIPTION
# 12-06-2018
In the original template, the reference package is defined as 
# \usepackage{natbib}
This way of defining neglects the semicolon in multiple author citations. 
Example: PVD is a data hiding technique derived from PEE (Shastri et al. 2018, Shaik et al. 2018)


To get the multiple author citations with semicolon I have updated the package with the command listed below 
# \usepackage[colan]{natbib}
Example: PVD is a data hiding technique derived from PEE (Shastri et al., 2018; Shaik et al., 2018)